### PR TITLE
Add LLM configuration popup

### DIFF
--- a/backend/handlers.py
+++ b/backend/handlers.py
@@ -295,12 +295,14 @@ def budget_remain(params):
         return reply
 
 import re
-def call_deepseek_budget_advice(records, total_budget=None):
+def call_deepseek_budget_advice(records, total_budget=None, llm=None):
     import os, requests, json
 
+    llm = llm or {}
+
     print("开始分配预算")
-    api_key = os.getenv("DEEPSEEK_API_KEY")
-    url = "https://api.siliconflow.cn/v1/chat/completions"
+    api_key = llm.get("apikey") or os.getenv("DEEPSEEK_API_KEY")
+    url = llm.get("url") or "https://api.siliconflow.cn/v1/chat/completions"
     headers = {
         "Authorization": f"Bearer {api_key}",
         "Content-Type": "application/json"
@@ -356,7 +358,7 @@ def call_deepseek_budget_advice(records, total_budget=None):
     )
 
     response = requests.post(url, headers=headers, json={
-        "model": "Pro/deepseek-ai/DeepSeek-V3",
+        "model": llm.get("model") or "Pro/deepseek-ai/DeepSeek-V3",
         "messages": [{"role": "user", "content": prompt}],
         "temperature": 0.5
     })
@@ -366,7 +368,7 @@ def call_deepseek_budget_advice(records, total_budget=None):
 
 
 
-def suggest_budgets(params=None):
+def suggest_budgets(params=None, llm=None):
     db = get_db()
     cursor = db.execute("SELECT category, amount, date FROM records")
     records = [dict(row) for row in cursor.fetchall()]
@@ -374,7 +376,7 @@ def suggest_budgets(params=None):
         return "📊 暂无支出记录，无法生成预算建议。"
 
     total = float(params.get("总预算", 0)) if params and "总预算" in params else None
-    llm_reply = call_deepseek_budget_advice(records, total)
+    llm_reply = call_deepseek_budget_advice(records, total, llm)
     print("🧠 LLM 预算建议回复：\n", llm_reply)
 
     # ✅ 解析 LLM 输出格式

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -20,6 +20,23 @@
             <component :is="Component" />
           </keep-alive>
         </router-view>
+        <el-dialog v-model="showConfig" title="LLM 设置" width="400px">
+          <el-form label-width="80px">
+            <el-form-item label="URL">
+              <el-input v-model="llmUrl" placeholder="https://api.example.com" />
+            </el-form-item>
+            <el-form-item label="API Key">
+              <el-input v-model="llmKey" />
+            </el-form-item>
+            <el-form-item label="模型名称">
+              <el-input v-model="llmModel" placeholder="Pro/deepseek-ai/DeepSeek-V3" />
+            </el-form-item>
+          </el-form>
+          <template #footer>
+            <el-button @click="useDefault">加载系统默认配置</el-button>
+            <el-button type="primary" @click="saveConfig">保存</el-button>
+          </template>
+        </el-dialog>
       </el-main>
     </el-container>
   </el-container>
@@ -27,15 +44,43 @@
 
 <script setup>
 import { useRoute, useRouter } from 'vue-router'
-import { ref, watchEffect } from 'vue'
+import { ref, watchEffect, onMounted, watch } from 'vue'
 
 const route = useRoute()
 const router = useRouter()
 const active = ref(route.path)
+const showConfig = ref(false)
+const llmUrl = ref('')
+const llmKey = ref('')
+const llmModel = ref('')
 
 watchEffect(() => {
   active.value = route.path
 })
+
+function checkConfig() {
+  if (route.path !== '/login' && !localStorage.getItem('llmConfig')) {
+    showConfig.value = true
+  }
+}
+
+onMounted(checkConfig)
+watch(() => route.path, checkConfig)
+
+function saveConfig() {
+  const cfg = {
+    url: llmUrl.value,
+    apikey: llmKey.value,
+    model: llmModel.value
+  }
+  localStorage.setItem('llmConfig', JSON.stringify(cfg))
+  showConfig.value = false
+}
+
+function useDefault() {
+  localStorage.setItem('llmConfig', 'default')
+  showConfig.value = false
+}
 
 function handleSelect(index) {
   router.push(index)

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -42,13 +42,18 @@ async function sendMessage() {
 
   try {
     const token = localStorage.getItem('token') || ''
+    const cfgRaw = localStorage.getItem('llmConfig')
+    let llm = null
+    if (cfgRaw && cfgRaw !== 'default') {
+      try { llm = JSON.parse(cfgRaw) } catch {}
+    }
     const res = await fetch('/chat', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${token}`
       },
-      body: JSON.stringify({ message: msg })
+      body: JSON.stringify({ message: msg, llm })
     })
     const data = await res.json()
     messages.value.push({ sender: 'assistant', content: data.reply || '⚠️ 无法解析' })


### PR DESCRIPTION
## Summary
- allow passing LLM config to backend and use it when calling LLM APIs
- show first‑login dialog to setup LLM URL, key and model

## Testing
- `python -m py_compile backend/app.py backend/handlers.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848d934b94c8332927ea5fc11bf0fb5