### PR TITLE
Add Windows deployment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ frontend/ # Vue 3 + Element Plus 前端应用
 
 在backend/中建立.env文件并设置api密钥
 
+### Linux / macOS
+
 执行以下命令可一键安装依赖并启动前后端：
 
 ```bash
@@ -27,11 +29,20 @@ chmod +x deploy.sh
 ./deploy.sh
 ```
 
+### Windows
+
+在 PowerShell 中运行：
+
+```powershell
+Set-ExecutionPolicy -Scope Process Bypass
+./deploy.ps1
+```
+
 前端默认运行在 [http://localhost:5173](http://localhost:5173)，后端接口运行在 [http://localhost:5000](http://localhost:5000)。
 
 ## 脚本说明
 
-`deploy.sh` 会完成以下工作：
+`deploy.sh`（Linux/macOS）与 `deploy.ps1`（Windows）会完成以下工作：
 
 1. 在 `backend/venv` 下创建虚拟环境并安装后端依赖；
 2. 安装前端依赖；

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -1,0 +1,33 @@
+# PowerShell deployment script for Windows
+$ErrorActionPreference = 'Stop'
+
+# === Backend Setup ===
+Push-Location backend
+if (-Not (Test-Path 'venv')) {
+    Write-Host '[backend] Creating virtual environment...'
+    python -m venv venv
+}
+.\venv\Scripts\Activate.ps1
+pip install --upgrade pip
+pip install -r requirements.txt
+$env:FLASK_APP = 'app.py'
+$backendProc = Start-Process 'waitress-serve' '--host=0.0.0.0 --port=5000 app:app' -NoNewWindow -PassThru
+deactivate
+Pop-Location
+
+# === Frontend Setup ===
+Push-Location frontend
+if (-Not (Test-Path 'node_modules')) {
+    Write-Host '[frontend] Installing node dependencies...'
+    npm install
+}
+$frontendProc = Start-Process 'npm' 'run dev' -NoNewWindow -PassThru
+Pop-Location
+
+Write-Host 'Servers started. Press Ctrl+C to stop...'
+try {
+    Wait-Process -Id $backendProc.Id, $frontendProc.Id
+} finally {
+    if ($backendProc -and !$backendProc.HasExited) { Stop-Process -Id $backendProc.Id }
+    if ($frontendProc -and !$frontendProc.HasExited) { Stop-Process -Id $frontendProc.Id }
+}


### PR DESCRIPTION
## Summary
- add a PowerShell deployment script for Windows
- document separate quick start instructions for Linux/macOS and Windows

## Testing
- `python -m py_compile backend/*.py`
- `npm install --dry-run`
- `bash -n deploy.sh`
- `pwsh -NoLogo -Command "Write-Output 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6848db579f908332b2c94acc1e3768d2