### PR TITLE
Add logout and model config controls

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -65,6 +65,14 @@ def login():
     tokens[token] = row["id"]
     return jsonify({"token": token})
 
+@app.route("/logout", methods=["POST"])
+@login_required
+def logout():
+    auth = request.headers.get("Authorization", "")
+    token = auth.replace("Bearer ", "")
+    tokens.pop(token, None)
+    return jsonify({"success": True})
+
 handlers = {
     "add_record": add_record,
     "add_income": add_income,  # ✅ 新增

--- a/backend/db.py
+++ b/backend/db.py
@@ -7,6 +7,12 @@ def get_db():
     conn.row_factory = sqlite3.Row
     return conn
 
+def column_exists(cur, table, column):
+    """Check if a column exists in a SQLite table."""
+    cur.execute(f"PRAGMA table_info({table})")
+    return any(row[1] == column for row in cur.fetchall())
+
+
 def init_db():
     conn = get_db()
     cur = conn.cursor()
@@ -79,6 +85,11 @@ def init_db():
         )
     """
     )
+
+    # 兼容旧版数据库，补充缺失的 user_id 字段
+    for tbl in ("records", "budgets", "categories", "income"):
+        if not column_exists(cur, tbl, "user_id"):
+            cur.execute(f"ALTER TABLE {tbl} ADD COLUMN user_id INTEGER")
 
     conn.commit()
     conn.close()

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,6 +11,11 @@
         <el-menu-item index="/chat">💬 聊天记账</el-menu-item>
         <el-menu-item index="/ledger">📒 账本管理</el-menu-item>
       </el-menu>
+      <div style="padding: 10px; text-align: center;">
+        <div style="margin-bottom:6px;">当前用户：{{ username }}</div>
+        <el-button size="small" @click="logout" style="margin-bottom:6px; width:100%">退出</el-button>
+        <el-button size="small" @click="openConfigPanel" style="width:100%">重新配置模型</el-button>
+      </div>
     </el-aside>
 
     <el-container>
@@ -53,9 +58,14 @@ const showConfig = ref(false)
 const llmUrl = ref('')
 const llmKey = ref('')
 const llmModel = ref('')
+const username = ref(localStorage.getItem('username') || '')
 
 watchEffect(() => {
   active.value = route.path
+})
+
+watchEffect(() => {
+  username.value = localStorage.getItem('username') || ''
 })
 
 function checkConfig() {
@@ -84,6 +94,18 @@ function useDefault() {
 
 function handleSelect(index) {
   router.push(index)
+}
+
+function logout() {
+  const token = localStorage.getItem('token') || ''
+  fetch('/logout', { method: 'POST', headers: { 'Authorization': `Bearer ${token}` } }).catch(() => {})
+  localStorage.removeItem('token')
+  localStorage.removeItem('username')
+  router.push('/login')
+}
+
+function openConfigPanel() {
+  showConfig.value = true
 }
 </script>
 

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -29,6 +29,7 @@ async function onLogin() {
   const data = await res.json()
   if (data.token) {
     localStorage.setItem('token', data.token)
+    localStorage.setItem('username', username.value)
     router.push('/chat')
   } else {
     alert(data.error || '登录失败')
@@ -43,7 +44,7 @@ async function onRegister() {
   })
   const data = await res.json()
   if (data.success) {
-    alert('注册成功，请登录')
+    await onLogin()
   } else {
     alert(data.error || '注册失败')
   }


### PR DESCRIPTION
## Summary
- add `/logout` endpoint
- show username with logout and LLM config buttons in sidebar
- auto-login after registration and store username

## Testing
- `python -m py_compile backend/app.py backend/db.py backend/handlers.py`
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848f7290eb883329df64eaf2f2f670d