### PR TITLE
Fix user display and chat state

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -11,11 +11,13 @@
         <el-menu-item index="/chat">💬 聊天记账</el-menu-item>
         <el-menu-item index="/ledger">📒 账本管理</el-menu-item>
       </el-menu>
-      <div style="padding: 10px; text-align: center;">
-        <div style="margin-bottom:6px;">当前用户：{{ username }}</div>
-        <el-button size="small" @click="logout" style="margin-bottom:6px; width:100%">退出</el-button>
+      <el-card class="user-panel" shadow="never">
+        <template #header>
+          <span>当前用户：{{ username }}</span>
+        </template>
+        <el-button type="primary" size="small" @click="logout" style="margin-bottom:8px; width:100%">退出</el-button>
         <el-button size="small" @click="openConfigPanel" style="width:100%">重新配置模型</el-button>
-      </div>
+      </el-card>
     </el-aside>
 
     <el-container>
@@ -58,15 +60,18 @@ const showConfig = ref(false)
 const llmUrl = ref('')
 const llmKey = ref('')
 const llmModel = ref('')
-const username = ref(localStorage.getItem('username') || '')
+const username = ref('')
 
 watchEffect(() => {
   active.value = route.path
 })
 
-watchEffect(() => {
+function updateUsername() {
   username.value = localStorage.getItem('username') || ''
-})
+}
+
+onMounted(updateUsername)
+watch(() => route.path, updateUsername)
 
 function checkConfig() {
   if (route.path !== '/login' && !localStorage.getItem('llmConfig')) {
@@ -113,6 +118,11 @@ function openConfigPanel() {
 body {
   margin: 0;
   font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+}
+.user-panel {
+  margin: 10px;
+  text-align: center;
+  padding-bottom: 10px;
 }
 </style>
 

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -23,7 +23,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, nextTick } from 'vue'
+import { ref, onMounted, onActivated, nextTick } from 'vue'
 import { useRouter } from 'vue-router'
 
 const userInput = ref('')
@@ -31,6 +31,7 @@ const messages = ref([{ sender: 'assistant', content: '你好，我是你的智�
 const loading = ref(false)
 const chatRef = ref(null)
 const router = useRouter()
+const currentUser = ref(localStorage.getItem('username') || '')
 
 async function sendMessage() {
   const msg = userInput.value.trim()
@@ -80,6 +81,16 @@ onMounted(() => {
     router.push('/login')
   } else {
     scrollToBottom()
+  }
+})
+
+onActivated(() => {
+  const name = localStorage.getItem('username') || ''
+  if (name !== currentUser.value) {
+    currentUser.value = name
+    messages.value = [
+      { sender: 'assistant', content: '你好，我是你的智能记账助手，有什么可以帮你？' }
+    ]
   }
 })
 </script>


### PR DESCRIPTION
## Summary
- display username inside a styled `el-card`
- refresh username when route changes
- reset chat messages when switching users

## Testing
- `npm run build` *(fails: vite not found)*
- `pytest`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848fcac07888332bf6517c2fedbb7cb