### PR TITLE
Improve user panel style

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,10 +1,10 @@
 <!-- src/App.vue 最终版本 -->
 <template>
   <el-container style="height: 100vh">
-    <el-aside v-if="route.path !== '/login'" width="200px" style="background: #f5f5f5;">
+    <el-aside v-if="route.path !== '/login'" width="200px" class="app-aside">
       <el-menu
         :default-active="active"
-        class="el-menu-vertical-demo"
+        class="el-menu-vertical-demo app-menu"
         @select="handleSelect"
         router
       >
@@ -15,8 +15,10 @@
         <template #header>
           <span>当前用户：{{ username }}</span>
         </template>
-        <el-button type="primary" size="small" @click="logout" style="margin-bottom:8px; width:100%">退出</el-button>
-        <el-button size="small" @click="openConfigPanel" style="width:100%">重新配置模型</el-button>
+        <div class="user-actions">
+          <el-button type="primary" size="small" @click="logout">退出</el-button>
+          <el-button size="small" @click="openConfigPanel">重新配置模型</el-button>
+        </div>
       </el-card>
     </el-aside>
 
@@ -121,8 +123,27 @@ body {
 }
 .user-panel {
   margin: 10px;
-  text-align: center;
-  padding-bottom: 10px;
+  padding: 10px;
+}
+
+.user-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.user-actions .el-button {
+  width: 100%;
+}
+
+.app-aside {
+  background: #f5f5f5;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-menu {
+  flex-grow: 1;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- adjust sidebar layout so user card stays at bottom
- style aside as flex column for consistent alignment

## Testing
- `python3 -m py_compile backend/*.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68490072d7848332bc7dfc06d39bd800