### PR TITLE
Fix startup auth and add logging

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -2,10 +2,19 @@ from flask import Flask, request, jsonify, g
 from db import init_db, get_db
 from handlers import *
 from dotenv import load_dotenv
-import os, requests, secrets
+import os, requests, secrets, logging
 from flask_cors import CORS
 from datetime import datetime
 from werkzeug.security import generate_password_hash, check_password_hash
+
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s: %(message)s',
+    handlers=[
+        logging.FileHandler('app.log', encoding='utf-8'),
+        logging.StreamHandler()
+    ]
+)
 
 app = Flask(__name__)
 CORS(app)

--- a/backend/run.sh
+++ b/backend/run.sh
@@ -2,4 +2,5 @@
 source venv/bin/activate
 export FLASK_APP=app.py
 export FLASK_ENV=development
-flask run --host=0.0.0.0
+flask run --host=0.0.0.0 --port=5000
+

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -6,13 +6,24 @@ import LoginView from '../views/LoginView.vue'
 const routes = [
   { path: '/', redirect: '/login' },
   { path: '/login', component: LoginView },
-  { path: '/chat', name: 'ChatView', component: ChatView },
-  { path: '/ledger', component: LedgerView }
+  { path: '/chat', name: 'ChatView', component: ChatView, meta: { requiresAuth: true } },
+  { path: '/ledger', component: LedgerView, meta: { requiresAuth: true } }
 ]
 
 const router = createRouter({
   history: createWebHistory(),
   routes
+})
+
+router.beforeEach((to, from, next) => {
+  if (to.meta.requiresAuth) {
+    const token = localStorage.getItem('token')
+    if (!token) {
+      next('/login')
+      return
+    }
+  }
+  next()
 })
 
 export default router

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -57,6 +57,9 @@ async function sendMessage() {
       body: JSON.stringify({ message: msg, llm })
     })
     const data = await res.json()
+    if (!res.ok) {
+      throw new Error(data.error || 'Server error')
+    }
     messages.value.push({ sender: 'assistant', content: data.reply || '⚠️ 无法解析' })
     if (data.reply?.startsWith('✅')) {
       localStorage.setItem('record_added', Date.now())


### PR DESCRIPTION
## Summary
- redirect unauthenticated users to login via navigation guard
- show server errors in chat view
- log backend output to `app.log`
- specify port in backend `run.sh`

## Testing
- `npm --version`
- `bash deploy.sh` *(fails: ProxyError when installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684924a5579883329d6077981185f71f