### PR TITLE
Improve mobile ledger layout

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -23,7 +23,14 @@
         </div>
       </el-card>
     </el-aside>
-    <el-drawer v-if="isMobile && route.path !== '/login'" v-model="showDrawer" :with-header="false" size="200px" class="app-aside">
+    <el-drawer
+      v-if="isMobile && route.path !== '/login'"
+      v-model="showDrawer"
+      :with-header="false"
+      size="200px"
+      class="app-aside"
+      direction="ltr"
+    >
       <el-menu
         :default-active="active"
         class="el-menu-vertical-demo app-menu"

--- a/frontend/src/components/BudgetAndCategoryPanel.vue
+++ b/frontend/src/components/BudgetAndCategoryPanel.vue
@@ -5,7 +5,7 @@
     </template>
 
     <!-- 月份选择 -->
-    <el-form :inline="true" size="small" class="mb-2" style="display: flex; align-items: center; gap: 10px">
+    <el-form :inline="true" size="small" class="mb-2 form-row">
       <el-form-item label="选择月份">
         <el-date-picker
           v-model="selectedMonth"
@@ -31,7 +31,7 @@
     </el-table>
 
     <!-- 添加/更新预算 -->
-    <el-form :inline="true" size="small" class="mb-3" style="display: flex; align-items: center; gap: 10px">
+    <el-form :inline="true" size="small" class="mb-3 form-row">
       <el-form-item label="分类">
         <el-select v-model="budgetForm.category" placeholder="选择分类">
           <el-option
@@ -119,5 +119,17 @@ watch(() => props.refreshFlag, fetchBudgets)
 <style scoped>
 .mb-2 { margin-bottom: 10px; }
 .mb-3 { margin-bottom: 15px; }
+.form-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+@media (max-width: 600px) {
+  .form-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
 </style>
 

--- a/frontend/src/components/CategoryManager.vue
+++ b/frontend/src/components/CategoryManager.vue
@@ -2,7 +2,7 @@
 <template>
   <el-card>
     <template #header>📁 分类管理</template>
-    <div style="display: flex; gap: 10px; align-items: center; margin-bottom: 10px">
+    <div class="input-row">
       <el-input v-model="newCategory" placeholder="新分类" style="flex: 1" />
       <el-button type="primary" size="small" @click="addCategory">添加</el-button>
     </div>
@@ -57,5 +57,21 @@ async function deleteCategory(name) {
 onMounted(fetchCategories)
 watch([() => props.refreshFlag, () => props.type], fetchCategories)
 </script>
+
+<style scoped>
+.input-row {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+@media (max-width: 600px) {
+  .input-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>
 
 

--- a/frontend/src/components/ChartPanel.vue
+++ b/frontend/src/components/ChartPanel.vue
@@ -5,7 +5,7 @@
       📊 收支图表分析
     </template>
 
-    <div style="margin-bottom: 10px; display: flex; align-items: center; gap: 10px">
+    <div class="toolbar">
       <el-radio-group v-model="mode">
         <el-radio-button label="month">按月</el-radio-button>
         <el-radio-button label="year">按年</el-radio-button>
@@ -14,13 +14,12 @@
         v-model="selectedTime"
         :type="mode === 'month' ? 'month' : 'year'"
         :value-format="mode === 'month' ? 'YYYY-MM' : 'YYYY'"
-        style="margin-left: 10px"
         @change="fetchChartData"
       />
-      <el-button style="margin-left: 10px" @click="showAll">查看全部</el-button>
+      <el-button class="ml" @click="showAll">查看全部</el-button>
     </div>
 
-    <div style="display: flex; gap: 20px; margin-bottom: 20px">
+    <div class="chart-row">
       <VChart :option="incomePieOption" style="height: 300px; flex: 1" />
       <VChart :option="spendPieOption" style="height: 300px; flex: 1" />
     </div>
@@ -157,6 +156,27 @@ watch(mode, () => {
 <style scoped>
 .v-chart {
   width: 100%;
+}
+.toolbar {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.toolbar .ml {
+  margin-left: 10px;
+}
+.chart-row {
+  display: flex;
+  gap: 20px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+@media (max-width: 600px) {
+  .chart-row {
+    flex-direction: column;
+  }
 }
 </style>
 

--- a/frontend/src/components/RecordTable.vue
+++ b/frontend/src/components/RecordTable.vue
@@ -3,7 +3,7 @@
   <el-card>
     <template #header>{{ title }}</template>
 
-    <el-form :inline="true" size="small" style="margin-bottom: 10px; display: flex; align-items: center; gap: 10px">
+    <el-form :inline="true" size="small" class="filter-form">
       <el-form-item label="类型">
         <el-select v-model="filterCategory" placeholder="全部" clearable style="width: 120px">
           <el-option
@@ -222,6 +222,22 @@ async function fetchData() {
 onMounted(fetchData)
 watch(() => props.refreshFlag, fetchData)
 </script>
+
+<style scoped>
+.filter-form {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+@media (max-width: 600px) {
+  .filter-form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>
 
 
 

--- a/frontend/src/components/SpendCharts.vue
+++ b/frontend/src/components/SpendCharts.vue
@@ -5,11 +5,7 @@
       📊 消费图表
     </template>
 
-    <el-form
-    :inline="true"
-    size="small"
-    style="margin-bottom: 10px; display: flex; align-items: center; gap: 10px;"
-    >
+    <el-form :inline="true" size="small">
     <el-form-item label="月份">
         <el-date-picker
         v-model="selectedMonth"
@@ -99,6 +95,22 @@ async function drawChart() {
 onMounted(drawChart)
 watch(() => props.refreshFlag, drawChart)
 </script>
+
+<style scoped>
+form {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+@media (max-width: 600px) {
+  form {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+</style>
 
 
 

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -107,6 +107,7 @@ onActivated(() => {
   flex: 1;
   overflow-y: auto;
   padding: 10px;
+  padding-bottom: 70px;
   background-color: #f9f9f9;
 }
 
@@ -138,7 +139,9 @@ onActivated(() => {
   padding: 10px;
   border-top: 1px solid #ddd;
   background: #fff;
-  position: sticky;
+  position: fixed;
+  left: 0;
+  right: 0;
   bottom: 0;
   z-index: 100;
 }

--- a/frontend/src/views/LedgerView.vue
+++ b/frontend/src/views/LedgerView.vue
@@ -25,7 +25,7 @@
     </el-tabs>
 
     <!-- 下半部分：左右两栏布局 -->
-    <div style="display: flex; gap: 20px; margin-top: 20px; align-items: flex-start">
+    <div class="ledger-layout">
       <!-- 左侧：预算管理和分类添加 -->
       <div style="flex: 1">
         <BudgetAndCategoryPanel
@@ -72,6 +72,21 @@ onMounted(() => {
 })
 onBeforeUnmount(() => window.removeEventListener('storage', onStorage))
 </script>
+
+<style scoped>
+.ledger-layout {
+  display: flex;
+  gap: 20px;
+  margin-top: 20px;
+  align-items: flex-start;
+}
+
+@media (max-width: 600px) {
+  .ledger-layout {
+    flex-direction: column;
+  }
+}
+</style>
 
 
 


### PR DESCRIPTION
## Summary
- make chart panel responsive for small screens
- wrap record filter toolbar on narrow displays
- adjust budget and category forms for mobile
- stack category input on mobile
- wrap spend charts form

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497996254883328ab7474f89304653