### PR TITLE
Fix chat page refresh 405

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ backend/  # Flask 后端服务 + sqlite 数据库
 frontend/ # Vue 3 + Element Plus 前端应用
 ```
 
-后端提供 `/chat` 等接口用于接收自然语言指令，前端包含聊天界面和账本管理页。
+后端提供 `/api/chat` 等接口用于接收自然语言指令，前端包含聊天界面和账本管理页。
 
 ## 快速开始
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, jsonify, g, session
+from flask import Flask, request, jsonify, g, session, send_from_directory
 from db import init_db, get_db
 from handlers import *
 from dotenv import load_dotenv
@@ -538,8 +538,6 @@ def get_budgets():
                 'month': b['month']
             })
 
-    return jsonify(result)
-
 @app.route("/api/categories", methods=["POST"])
 @login_required
 def add_category_manual():
@@ -820,3 +818,17 @@ def daily_stats():
         })
 
     return jsonify(result)
+
+# ======= Serve Frontend =======
+@app.route("/", defaults={"path": ""})
+@app.route("/<path:path>")
+def serve_frontend(path):
+    """Serve built frontend assets for any non-API GET route."""
+    if path.startswith("api"):
+        return jsonify({"error": "Not Found"}), 404
+
+    dist_dir = os.path.join(os.path.dirname(__file__), "..", "frontend", "dist")
+    file_path = os.path.join(dist_dir, path)
+    if path and os.path.isfile(file_path):
+        return send_from_directory(dist_dir, path)
+    return send_from_directory(dist_dir, "index.html")

--- a/backend/app.py
+++ b/backend/app.py
@@ -30,7 +30,7 @@ def login_required(f):
     return wrapper
 
 
-@app.route("/register", methods=["POST"])
+@app.route("/api/register", methods=["POST"])
 def register():
     data = request.get_json() or {}
     username = data.get("username", "").strip()
@@ -49,7 +49,7 @@ def register():
     return jsonify({"success": True})
 
 
-@app.route("/login", methods=["POST"])
+@app.route("/api/login", methods=["POST"])
 def login():
     data = request.get_json() or {}
     username = data.get("username", "").strip()
@@ -63,7 +63,7 @@ def login():
     session["username"] = username
     return jsonify({"success": True})
 
-@app.route("/logout", methods=["POST"])
+@app.route("/api/logout", methods=["POST"])
 @login_required
 def logout():
     session.pop("user_id", None)
@@ -248,7 +248,7 @@ def parse_response(text):
 
     return intent, params
 
-@app.route("/chat", methods=["POST"])
+@app.route("/api/chat", methods=["POST"])
 @login_required
 def chat():
     data = request.get_json()
@@ -305,7 +305,7 @@ def chat():
 
     return jsonify({"reply": reply}) 
 
-@app.route('/records')
+@app.route('/api/records')
 @login_required
 def get_records():
     db = get_db()
@@ -333,7 +333,7 @@ def get_records():
     results = [dict(row) for row in cursor.fetchall()]
     return jsonify(results)
 
-@app.route('/records/<int:record_id>', methods=['DELETE'])
+@app.route('/api/records/<int:record_id>', methods=['DELETE'])
 @login_required
 def delete_record(record_id):
     db = get_db()
@@ -344,7 +344,7 @@ def delete_record(record_id):
     db.commit()
     return jsonify({"success": True})
 
-@app.route('/records/<int:record_id>', methods=['PUT'])
+@app.route('/api/records/<int:record_id>', methods=['PUT'])
 @login_required
 def update_record(record_id):
     data = request.get_json()
@@ -365,7 +365,7 @@ def update_record(record_id):
     db.commit()
     return jsonify({"success": True})
 
-@app.route('/income')
+@app.route('/api/income')
 @login_required
 def get_income():
     db = get_db()
@@ -401,7 +401,7 @@ def get_income():
 
     return jsonify(results)
 
-@app.route('/income/<int:income_id>', methods=['DELETE'])
+@app.route('/api/income/<int:income_id>', methods=['DELETE'])
 @login_required
 def delete_income(income_id):
     db = get_db()
@@ -412,7 +412,7 @@ def delete_income(income_id):
     db.commit()
     return jsonify({"success": True})
 
-@app.route('/income/<int:income_id>', methods=['PUT'])
+@app.route('/api/income/<int:income_id>', methods=['PUT'])
 @login_required
 def update_income(income_id):
     data = request.get_json()
@@ -433,7 +433,7 @@ def update_income(income_id):
     db.commit()
     return jsonify({"success": True})
 
-@app.route("/categories", methods=["GET"])
+@app.route("/api/categories", methods=["GET"])
 @login_required
 def get_categories():
     db = get_db()
@@ -462,7 +462,7 @@ def get_categories():
 
 
 month = datetime.now().strftime("%Y-%m")
-@app.route('/budgets')
+@app.route('/api/budgets')
 @login_required
 def get_budgets():
     db = get_db()
@@ -540,7 +540,7 @@ def get_budgets():
 
     return jsonify(result)
 
-@app.route("/categories", methods=["POST"])
+@app.route("/api/categories", methods=["POST"])
 @login_required
 def add_category_manual():
     data = request.get_json()
@@ -565,7 +565,7 @@ def add_category_manual():
 
 
 
-@app.route("/categories/<name>", methods=["DELETE"])
+@app.route("/api/categories/<name>", methods=["DELETE"])
 @login_required
 def delete_category_manual(name):
     db = get_db()
@@ -593,7 +593,7 @@ def delete_category_manual(name):
 
     return jsonify({"success": True})
 
-@app.route("/budgets", methods=["POST"])
+@app.route("/api/budgets", methods=["POST"])
 @login_required
 def set_budget_manual():
     data = request.get_json()
@@ -630,7 +630,7 @@ def set_budget_manual():
 
 
 
-@app.route("/stats/monthly", methods=["GET"])
+@app.route("/api/stats/monthly", methods=["GET"])
 @login_required
 def monthly_stats():
     db = get_db()
@@ -692,7 +692,7 @@ def monthly_stats():
 
     return jsonify(result)
 
-@app.route("/stats/by-category", methods=["GET"])
+@app.route("/api/stats/by-category", methods=["GET"])
 @login_required
 def category_stats():
     db = get_db()
@@ -737,7 +737,7 @@ def category_stats():
     ]
     return jsonify(spend_result + income_result)
 
-@app.route("/stats/summary", methods=["GET"])
+@app.route("/api/stats/summary", methods=["GET"])
 @login_required
 def summary_stats():
     db = get_db()
@@ -775,7 +775,7 @@ def summary_stats():
         "结余": round(balance, 2)
     })
 
-@app.route("/stats/daily")
+@app.route("/api/stats/daily")
 @login_required
 def daily_stats():
     db = get_db()

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -149,7 +149,7 @@ function handleSelect(index) {
 }
 
 function logout() {
-  fetch('/logout', { method: 'POST', credentials: 'include' }).catch(() => {})
+  fetch('/api/logout', { method: 'POST', credentials: 'include' }).catch(() => {})
   localStorage.removeItem('username')
   router.push('/login')
 }

--- a/frontend/src/components/BudgetAndCategoryPanel.vue
+++ b/frontend/src/components/BudgetAndCategoryPanel.vue
@@ -90,15 +90,15 @@ const budgetForm = ref({
 async function fetchBudgets() {
   const month = selectedMonth.value
   const [bRes, cRes] = await Promise.all([
-    api.get('/budgets', { params: { month } }),
-    api.get('/categories', { params: { type: 'expense' } })
+    api.get('/api/budgets', { params: { month } }),
+    api.get('/api/categories', { params: { type: 'expense' } })
   ])
   budgets.value = bRes.data
   expenseCategories.value = cRes.data.map(c => c.name)
 }
 
 async function submitBudget() {
-  await api.post('/budgets', {
+  await api.post('/api/budgets', {
     category: budgetForm.value.category,
     amount: budgetForm.value.amount,
     month: selectedMonth.value

--- a/frontend/src/components/BudgetManager.vue
+++ b/frontend/src/components/BudgetManager.vue
@@ -60,7 +60,7 @@ const currentMonth = new Date().toISOString().slice(0, 7)
 const selectedMonth = ref(currentMonth)
 
 async function fetchBudgets() {
-  const res = await api.get('/budgets', {
+  const res = await api.get('/api/budgets', {
     params: { month: selectedMonth.value }
   })
   budgets.value = res.data
@@ -68,7 +68,7 @@ async function fetchBudgets() {
 
 async function addOrUpdateBudget() {
   if (!newBudget.value.category || !newBudget.value.amount) return
-  await api.post('/budgets', {
+  await api.post('/api/budgets', {
     ...newBudget.value,
     month: selectedMonth.value
   })

--- a/frontend/src/components/CategoryManager.vue
+++ b/frontend/src/components/CategoryManager.vue
@@ -31,7 +31,7 @@ const categories = ref([])
 const newCategory = ref('')
 
 async function fetchCategories() {
-  const res = await api.get('/categories', {
+  const res = await api.get('/api/categories', {
     params: { type: props.type }
   })
   categories.value = res.data
@@ -39,7 +39,7 @@ async function fetchCategories() {
 
 async function addCategory() {
   if (!newCategory.value) return
-  await api.post('/categories', {
+  await api.post('/api/categories', {
     name: newCategory.value,
     type: props.type === 'income' ? '收入' : '支出'
   })
@@ -49,7 +49,7 @@ async function addCategory() {
 }
 
 async function deleteCategory(name) {
-  await api.delete(`/categories/${encodeURIComponent(name)}`)
+  await api.delete(`/api/categories/${encodeURIComponent(name)}`)
   await fetchCategories()
   emit('refresh')
 }

--- a/frontend/src/components/ChartPanel.vue
+++ b/frontend/src/components/ChartPanel.vue
@@ -74,10 +74,10 @@ const fetchChartData = async () => {
     catParams.year = time
   }
   const [cats, trend] = await Promise.all([
-    api.get('/stats/by-category', { params: catParams }),
+    api.get('/api/stats/by-category', { params: catParams }),
     mode.value === 'month'
-      ? api.get('/stats/daily', { params: { month: time } })
-      : api.get('/stats/monthly', { params: time ? { year: time } : {} })
+      ? api.get('/api/stats/daily', { params: { month: time } })
+      : api.get('/api/stats/monthly', { params: time ? { year: time } : {} })
   ])
 
   const incomeCats = cats.data.filter(x => x['类型'] === '收入')

--- a/frontend/src/components/RecordTable.vue
+++ b/frontend/src/components/RecordTable.vue
@@ -145,7 +145,7 @@ function startEdit(row) {
 }
 
 async function saveEdit(row) {
-  const url = props.type === 'expense' ? `/records/${row.id}` : `/income/${row.id}`
+  const url = props.type === 'expense' ? `/api/records/${row.id}` : `/api/income/${row.id}`
   await api.put(url, row)
   editingId.value = null
   await fetchData()
@@ -159,7 +159,7 @@ function cancelEdit() {
 
 async function deleteSelected() {
   for (const r of selectedRows.value) {
-    const url = props.type === 'expense' ? `/records/${r.id}` : `/income/${r.id}`
+    const url = props.type === 'expense' ? `/api/records/${r.id}` : `/api/income/${r.id}`
     await api.delete(url)
   }
   selectedRows.value = []
@@ -181,8 +181,8 @@ function applyFilter() {
 async function fetchData() {
   try {
     const [recRes, catRes] = await Promise.all([
-      api.get(props.type === 'expense' ? '/records' : '/income'),
-      api.get('/categories', {
+      api.get(props.type === 'expense' ? '/api/records' : '/api/income'),
+      api.get('/api/categories', {
         params: {
           type: props.type === 'expense' ? 'expense' : 'income'
         }
@@ -195,7 +195,7 @@ async function fetchData() {
     console.log("📋 收入数据：", rec)
     console.log("📂 分类数据：", cats)
     if (props.type === 'expense') {
-      const budgets = (await api.get('/budgets')).data
+      const budgets = (await api.get('/api/budgets')).data
       const budgetMap = {}
       for (const b of budgets) {
         budgetMap[b.category + '_' + b.month] = b.amount

--- a/frontend/src/components/SpendCharts.vue
+++ b/frontend/src/components/SpendCharts.vue
@@ -49,7 +49,7 @@ function resetMonth() {
 }
 
 async function drawChart() {
-  const res = await api.get('/records', {
+  const res = await api.get('/api/records', {
     params: selectedMonth.value ? { month: selectedMonth.value } : {}
   })
   const data = res.data

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -47,7 +47,7 @@ async function sendMessage() {
     if (cfgRaw && cfgRaw !== 'default') {
       try { llm = JSON.parse(cfgRaw) } catch {}
     }
-    const res = await fetch('/chat', {
+    const res = await fetch('/api/chat', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -21,7 +21,7 @@ const username = ref('')
 const password = ref('')
 
 async function onLogin() {
-  const res = await fetch('/login', {
+  const res = await fetch('/api/login', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
@@ -37,7 +37,7 @@ async function onLogin() {
 }
 
 async function onRegister() {
-  const res = await fetch('/register', {
+  const res = await fetch('/api/register', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,14 +9,7 @@ export default defineConfig({
     port: 5173,
     open: true,
     proxy: {
-      '/chat': 'http://localhost:5000',
-      '/login': 'http://localhost:5000',
-      '/register': 'http://localhost:5000',
-      '/records': 'http://localhost:5000',
-      '/categories': 'http://localhost:5000',
-      '/budgets': 'http://localhost:5000',
-      '/income': 'http://localhost:5000',
-      '/stats': 'http://localhost:5000'
+      '/api': 'http://localhost:5000'
     }
   },
   resolve: {


### PR DESCRIPTION
## Summary
- prefix backend API routes with `/api` to avoid collision with front-end routes
- update frontend fetch/axios calls to use the new `/api` paths
- simplify Vite proxy config to forward `/api` requests to Flask backend
- document new API prefix in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a377ef20c83329e32ec036fd36b98