### PR TITLE
Add decimal formatting for financial numbers

### DIFF
--- a/frontend/src/components/BudgetAndCategoryPanel.vue
+++ b/frontend/src/components/BudgetAndCategoryPanel.vue
@@ -26,8 +26,12 @@
       style="width: 100%"
     >
       <el-table-column prop="category" label="分类" />
-      <el-table-column prop="amount" label="预算额" />
-      <el-table-column prop="remaining" label="剩余预算" />
+      <el-table-column prop="amount" label="预算额">
+        <template #default="scope">{{ Number(scope.row.amount).toFixed(2) }}</template>
+      </el-table-column>
+      <el-table-column prop="remaining" label="剩余预算">
+        <template #default="scope">{{ Number(scope.row.remaining).toFixed(2) }}</template>
+      </el-table-column>
     </el-table>
 
     <!-- 添加/更新预算 -->

--- a/frontend/src/components/BudgetManager.vue
+++ b/frontend/src/components/BudgetManager.vue
@@ -36,8 +36,12 @@
     <!-- 预算列表 -->
     <el-table :data="budgets" style="margin-top: 10px">
       <el-table-column prop="category" label="分类" />
-      <el-table-column prop="amount" label="预算金额" />
-      <el-table-column prop="remaining" label="剩余预算" />
+      <el-table-column prop="amount" label="预算金额">
+        <template #default="scope">{{ Number(scope.row.amount).toFixed(2) }}</template>
+      </el-table-column>
+      <el-table-column prop="remaining" label="剩余预算">
+        <template #default="scope">{{ Number(scope.row.remaining).toFixed(2) }}</template>
+      </el-table-column>
     </el-table>
 
     <!-- 底部说明 -->

--- a/frontend/src/components/ChartPanel.vue
+++ b/frontend/src/components/ChartPanel.vue
@@ -30,7 +30,9 @@
         <VChart :option="spendPieOption" style="height: 300px" />
       </div>
     </div>
-    <VChart :option="lineOption" style="height: 300px" />
+    <div class="line-wrapper">
+      <VChart :option="lineOption" style="height: 300px" />
+    </div>
   </el-card>
 </template>
 
@@ -222,6 +224,10 @@ watch(mode, () => {
 .summary-text {
   font-weight: bold;
   margin-left: 10px;
+}
+.line-wrapper {
+  display: flex;
+  justify-content: center;
 }
 </style>
 

--- a/frontend/src/components/ChartPanel.vue
+++ b/frontend/src/components/ChartPanel.vue
@@ -17,17 +17,17 @@
         @change="fetchChartData"
       />
       <el-button class="ml" @click="showAll">查看全部</el-button>
+      <span class="summary-text">总收入：{{ incomeTotal.toFixed(2) }}</span>
+      <span class="summary-text">总支出：{{ spendTotal.toFixed(2) }}</span>
+      <span class="summary-text">结余：{{ balance.toFixed(2) }}</span>
     </div>
 
     <div class="chart-row">
       <div class="pie-wrapper">
         <VChart :option="incomePieOption" style="height: 300px" />
-        <div class="total-text">总收入：{{ incomeTotal.toFixed(2) }}</div>
       </div>
-      <div class="balance-wrapper">结余：{{ balance.toFixed(2) }}</div>
       <div class="pie-wrapper">
         <VChart :option="spendPieOption" style="height: 300px" />
-        <div class="total-text">总支出：{{ spendTotal.toFixed(2) }}</div>
       </div>
     </div>
     <VChart :option="lineOption" style="height: 300px" />
@@ -213,28 +213,15 @@ watch(mode, () => {
   display: flex;
   gap: 20px;
   margin-bottom: 20px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 .pie-wrapper {
   flex: 1;
   text-align: center;
 }
-.total-text {
-  margin-top: 5px;
-  font-size: 14px;
-  color: #555;
-}
-.balance-wrapper {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 10px;
+.summary-text {
   font-weight: bold;
-}
-@media (max-width: 600px) {
-  .chart-row {
-    flex-direction: column;
-  }
+  margin-left: 10px;
 }
 </style>
 

--- a/frontend/src/components/RecordTable.vue
+++ b/frontend/src/components/RecordTable.vue
@@ -70,7 +70,7 @@
           <template v-if="editingId === scope.row.id">
             <el-input-number v-model="scope.row.amount" :min="0" />
           </template>
-          <template v-else>{{ scope.row.amount }}</template>
+          <template v-else>{{ Number(scope.row.amount).toFixed(2) }}</template>
         </template>
       </el-table-column>
       <el-table-column v-if="showBudget" prop="left_budget" label="剩余预算" sortable />

--- a/frontend/src/components/SpendCharts.vue
+++ b/frontend/src/components/SpendCharts.vue
@@ -57,11 +57,11 @@ async function drawChart() {
   // 分组
   const grouped = {}
   for (const item of data) {
-    grouped[item.category] = (grouped[item.category] || 0) + item.amount
+    grouped[item.category] = (grouped[item.category] || 0) + Number(item.amount)
   }
 
   const labels = Object.keys(grouped)
-  const amounts = Object.values(grouped)
+  const amounts = Object.values(grouped).map(v => Number(v.toFixed(2)))
 
   if (chartInstance) chartInstance.destroy()
   chartInstance = new Chart(chartRef.value.getContext('2d'), {

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -8,6 +8,7 @@
         <el-button type="primary" @click="onLogin">登录</el-button>
         <el-button @click="onRegister">注册</el-button>
       </div>
+      <p class="register-tip">新用户请输入用户名和密码后点击注册即可登录</p>
     </el-card>
   </div>
 </template>
@@ -72,5 +73,10 @@ async function onRegister() {
   align-items: center;
   height: 100vh;
   height: 100dvh;
+}
+.register-tip {
+  color: #888;
+  margin-top: 10px;
+  font-size: 13px;
 }
 </style>


### PR DESCRIPTION
## Summary
- ensure totals below pie charts use two-decimal formatting
- round category and trend data before feeding into charts
- display amounts with two decimals in RecordTable
- format budget tables and SpendCharts data with two decimals

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae3ba2ca88332b784f2a044b6650d