### PR TITLE
Adjust chart panel layout

### DIFF
--- a/frontend/src/components/ChartPanel.vue
+++ b/frontend/src/components/ChartPanel.vue
@@ -30,7 +30,9 @@
         <VChart :option="spendPieOption" style="height: 300px" />
       </div>
     </div>
-    <VChart :option="lineOption" style="height: 300px" />
+    <div class="line-wrapper">
+      <VChart :option="lineOption" style="height: 300px" />
+    </div>
   </el-card>
 </template>
 
@@ -222,6 +224,10 @@ watch(mode, () => {
 .summary-text {
   font-weight: bold;
   margin-left: 10px;
+}
+.line-wrapper {
+  display: flex;
+  justify-content: center;
 }
 </style>
 

--- a/frontend/src/components/ChartPanel.vue
+++ b/frontend/src/components/ChartPanel.vue
@@ -17,17 +17,17 @@
         @change="fetchChartData"
       />
       <el-button class="ml" @click="showAll">查看全部</el-button>
+      <span class="summary-text">总收入：{{ incomeTotal.toFixed(2) }}</span>
+      <span class="summary-text">总支出：{{ spendTotal.toFixed(2) }}</span>
+      <span class="summary-text">结余：{{ balance.toFixed(2) }}</span>
     </div>
 
     <div class="chart-row">
       <div class="pie-wrapper">
         <VChart :option="incomePieOption" style="height: 300px" />
-        <div class="total-text">总收入：{{ incomeTotal.toFixed(2) }}</div>
       </div>
-      <div class="balance-wrapper">结余：{{ balance.toFixed(2) }}</div>
       <div class="pie-wrapper">
         <VChart :option="spendPieOption" style="height: 300px" />
-        <div class="total-text">总支出：{{ spendTotal.toFixed(2) }}</div>
       </div>
     </div>
     <VChart :option="lineOption" style="height: 300px" />
@@ -213,28 +213,15 @@ watch(mode, () => {
   display: flex;
   gap: 20px;
   margin-bottom: 20px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
 }
 .pie-wrapper {
   flex: 1;
   text-align: center;
 }
-.total-text {
-  margin-top: 5px;
-  font-size: 14px;
-  color: #555;
-}
-.balance-wrapper {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0 10px;
+.summary-text {
   font-weight: bold;
-}
-@media (max-width: 600px) {
-  .chart-row {
-    flex-direction: column;
-  }
+  margin-left: 10px;
 }
 </style>
 


### PR DESCRIPTION
## Summary
- keep pie charts in a row on small screens
- show income, expense and balance totals next to the 'view all' button

## Testing
- `npm install` *(fails: vite not found)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aef4cdcc08332ba5ca6eafb530cfb