### PR TITLE
Add persistent llm config

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -88,6 +88,19 @@ def init_db():
     """
     )
 
+    # ✅ LLM 配置表，每个用户一条记录
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS llm_config (
+            user_id INTEGER PRIMARY KEY,
+            url TEXT,
+            apikey TEXT,
+            model TEXT,
+            persona TEXT
+        )
+    """
+    )
+
     # ✅ 补充缺失的 is_admin 字段（向后兼容）
     if not column_exists(cur, "users", "is_admin"):
         cur.execute("ALTER TABLE users ADD COLUMN is_admin INTEGER DEFAULT 0")

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -150,7 +150,16 @@ watch(() => route.path, updateUsername)
 
 function checkConfig() {
   if (route.path !== '/login' && !localStorage.getItem('llmConfig')) {
-    showConfig.value = true
+    fetch('/api/llm_config', { credentials: 'include' })
+      .then(res => res.ok ? res.json() : null)
+      .then(cfg => {
+        if (cfg && Object.keys(cfg).length) {
+          localStorage.setItem('llmConfig', JSON.stringify(cfg))
+        } else {
+          showConfig.value = true
+        }
+      })
+      .catch(() => { showConfig.value = true })
   }
 }
 
@@ -164,11 +173,23 @@ function saveConfig() {
     model: llmModel.value,
     persona: llmPersona.value
   }
+  fetch('/api/llm_config', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(cfg)
+  }).catch(() => {})
   localStorage.setItem('llmConfig', JSON.stringify(cfg))
   showConfig.value = false
 }
 
 function useDefault() {
+  fetch('/api/llm_config', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({})
+  }).catch(() => {})
   localStorage.setItem('llmConfig', 'default')
   showConfig.value = false
 }
@@ -182,6 +203,7 @@ function logout() {
   fetch('/api/logout', { method: 'POST', credentials: 'include' }).catch(() => {})
   localStorage.removeItem('username')
   localStorage.removeItem('is_admin')
+  localStorage.removeItem('llmConfig')
   router.push('/login')
 }
 

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -44,6 +44,17 @@ async function onLogin() {
     } else {
       localStorage.removeItem('is_admin')
     }
+    try {
+      const cfgRes = await fetch('/api/llm_config', { credentials: 'include' })
+      if (cfgRes.ok) {
+        const cfg = await cfgRes.json()
+        if (Object.keys(cfg).length) {
+          localStorage.setItem('llmConfig', JSON.stringify(cfg))
+        } else {
+          localStorage.removeItem('llmConfig')
+        }
+      }
+    } catch {}
     router.push('/chat')
   } else {
     alert(data.error || '登录失败')


### PR DESCRIPTION
## Summary
- add `llm_config` table
- implement `/api/llm_config` API
- save/load model configuration via API in frontend

## Testing
- `python -m py_compile backend/*.py`
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d2a07d26c8332a2ec09282ddfdaed