### PR TITLE
Improve record table defaults

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -415,7 +415,7 @@ def get_records():
             SELECT *, strftime('%Y-%m', date) as month
             FROM records
             WHERE strftime('%Y-%m', date) = ? AND user_id = ?
-            ORDER BY date DESC
+            ORDER BY date DESC, id DESC
         """,
             (month, g.user_id)
         )
@@ -425,7 +425,7 @@ def get_records():
             SELECT *, strftime('%Y-%m', date) as month
             FROM records
             WHERE user_id = ?
-            ORDER BY date DESC
+            ORDER BY date DESC, id DESC
         """,
             (g.user_id,)
         )
@@ -476,7 +476,7 @@ def get_income():
             SELECT id, category, amount, note, date, month, year
             FROM income
             WHERE month = ? AND user_id = ?
-            ORDER BY date DESC
+            ORDER BY date DESC, id DESC
         """,
             (month, g.user_id)
         )
@@ -486,7 +486,7 @@ def get_income():
             SELECT id, category, amount, note, date, month, year
             FROM income
             WHERE user_id = ?
-            ORDER BY date DESC
+            ORDER BY date DESC, id DESC
         """,
             (g.user_id,)
         )

--- a/frontend/src/components/RecordTable.vue
+++ b/frontend/src/components/RecordTable.vue
@@ -116,6 +116,7 @@ const filtered = ref([])
 const categories = ref([])
 const filterCategory = ref('')
 const dateRange = ref([])
+const today = new Date().toISOString().slice(0, 10)
 const selectedRows = ref([])
 const editingId = ref(null)
 const pageSize = 10
@@ -189,7 +190,10 @@ async function fetchData() {
       })
     ])
 
-    const rec = recRes.data
+    const rec = recRes.data.sort((a, b) => {
+      if (a.date === b.date) return b.id - a.id
+      return b.date.localeCompare(a.date)
+    })
     const cats = catRes.data.map(c => c.name)
     categories.value = cats
     console.log("📋 收入数据：", rec)
@@ -219,7 +223,10 @@ async function fetchData() {
 }
 
 
-onMounted(fetchData)
+onMounted(() => {
+  dateRange.value = [today, today]
+  fetchData()
+})
 watch(() => props.refreshFlag, fetchData)
 </script>
 


### PR DESCRIPTION
## Summary
- order backend record queries by date then id
- on the front end filter to show today's records by default
- sort records locally so newest records show first

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685abbae23688332ad29d1187f881a7b